### PR TITLE
Implement 'aiofiles.os.walk' via a queue and generators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,11 @@ ENV/
 env.bak/
 venv.bak/
 
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
@@ -92,3 +97,6 @@ venv.bak/
 
 # Visual Studio Code
 .vscode/
+
+# ruff stuff:
+.ruff_cache/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
-.PHONY: test lint
+SRC_DIR := src
+TESTS_DIR := tests
+TARGET_DIRS := $(SRC_DIR) $(TESTS_DIR)
+
+.PHONY: format lint test
+
+format:
+	pdm run black $(TARGET_DIRS)
 
 test:
-	pdm run pytest -x --ff tests
+	pdm run pytest -x --ff $(TESTS_DIR)
 
 lint:
-	pdm run flake8 src tests && pdm run black --check src tests
+	pdm run flake8 $(TARGET_DIRS) && pdm run black --check $(TARGET_DIRS)

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -3,9 +3,12 @@
 import asyncio
 import os
 import platform
+import time
+from collections import defaultdict
 from os import stat
 from os.path import dirname, exists, isdir, join
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -531,3 +534,63 @@ async def test_walk(top, topdown, onerror, followlinks):
     ]
 
     assert result == answer
+
+
+@pytest.mark.parametrize(
+    "top_path",
+    [
+        "c3Po-ar2D2",  # does not mean to exist
+        "./src",
+        "./tests",
+        # ".",  # is long
+    ],
+)
+async def test_walk_non_blocking(top_path: str):
+    async def _test_walk(
+        top: str, key: str, storage: defaultdict[str, list]
+    ) -> dict[str, Any]:
+        stat: dict[str, Any] = {"status": None, "time": None}
+
+        start = time.time()
+        async for datum in aiofiles.os.walk(top=top):
+            storage[key].append(datum)
+            # no need to block the `async for` loop
+            await asyncio.sleep(0)
+        end = time.time() - start
+
+        stat["status"] = True
+        stat["time"] = end
+
+        # only a non-empty result is checked
+        if storage[key]:
+            other_keys = set(storage) - {key}
+            stat["status"] = any([storage[other_key] for other_key in other_keys])
+
+        return stat
+
+    keys = {f"w_{i}" for i in range(2)}
+    storage = defaultdict(list)
+
+    # measuring time
+
+    start_time = time.time()
+    tasks: list[asyncio.Task] = [
+        asyncio.create_task(_test_walk(top=top_path, key=key, storage=storage))
+        for key in keys
+    ]
+    results = await asyncio.gather(*tasks)
+    elapsed_time = time.time() - start_time
+
+    # preparing and asserting
+
+    codes = {result["status"] for result in results}
+    assert codes
+    assert all(codes)
+
+    times = {result["time"] for result in results}
+    assert times
+    assert all([t < elapsed_time for t in times])
+
+    for wkey, wresult in storage.items():
+        for other_key in set(storage) - {wkey}:
+            assert storage[other_key] == wresult


### PR DESCRIPTION
A queue-based solution for the [aiofiles/PR-193](https://github.com/Tinche/aiofiles/pull/193) .